### PR TITLE
fix: redirecionamentos client-side

### DIFF
--- a/app/(system)/tickets/page.tsx
+++ b/app/(system)/tickets/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import axios from "axios";
 import useSWR from "swr";
 import { useSession } from "next-auth/react";
-import { redirect } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { jwtDecode } from "jwt-decode";
 import { Button } from "@/components/ui/button";
 import Icon, { IconNames } from "@/components/ui/icons";
@@ -91,6 +91,7 @@ function getGroupIdFromSession(
 
 export default function Tickets() {
   const { data: session, status } = useSession();
+  const router = useRouter();
   const [searchTerm, setSearchTerm] = useState("");
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [dialogConfimationMessage, setDialogConfimationMessage] =
@@ -135,12 +136,21 @@ export default function Tickets() {
     setPage(1);
   }, [trimmedSearch]);
 
+  const shouldRedirectToFirstAccess =
+    status !== "loading" && session?.challengeName === "NEW_PASSWORD_REQUIRED";
+
+  useEffect(() => {
+    if (shouldRedirectToFirstAccess) {
+      router.replace("/first-access");
+    }
+  }, [shouldRedirectToFirstAccess, router]);
+
   if (status === "loading") {
     return <div>Carregando...</div>;
   }
 
-  if (session?.challengeName === "NEW_PASSWORD_REQUIRED") {
-    redirect("/first-access");
+  if (shouldRedirectToFirstAccess) {
+    return <div>Redirecionando...</div>;
   }
 
   const embeddedTickets: TicketsApiTicket[] = ticketsData?.tasks ?? [];


### PR DESCRIPTION
## Resumo
- Substitui redirect() por useRouter().replace em components client-side.
- Corrige rota final de primeiro acesso para /tickets.

## Testes
- yarn lint (falhou: erros de lint pendentes em #10)

Closes #3