### PR TITLE
fix: validar senha conforme politica

### DIFF
--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -22,15 +22,28 @@ import { useRouter, useSearchParams } from "next/navigation";
 import axios from "axios";
 import { API_BASE_URL } from "@/shared/api";
 
-const formSchema = z.object({
-  password: z.string().min(2, {
-    message: "A senha é obrigatória.",
-  }),
+const passwordPolicyRegex =
+  /^(?=.*[A-Z])(?=(?:.*\d){3,})(?=.*[^A-Za-z0-9]).{8,}$/;
 
-  confirmPassword: z.string().min(2, {
-    message: "A confirmação de senha é obrigatória.",
-  }),
-});
+const formSchema = z
+  .object({
+    password: z
+      .string()
+      .min(8, {
+        message: "A senha deve ter no mínimo 8 caracteres.",
+      })
+      .regex(passwordPolicyRegex, {
+        message:
+          "A senha deve conter pelo menos 1 letra maiúscula, 3 números e 1 caractere especial.",
+      }),
+    confirmPassword: z.string().min(1, {
+      message: "A confirmação de senha é obrigatória.",
+    }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    path: ["confirmPassword"],
+    message: "As senhas não conferem.",
+  });
 
 export default function ResetPassword() {
   const [disableForm, setdisableForm] = useState<boolean>(false);
@@ -50,14 +63,6 @@ export default function ResetPassword() {
   const code = searchParams.get("code");
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    if (values.password !== values.confirmPassword) {
-      setErrorMessage("As senhas não conferem.");
-      setTimeout(() => {
-        setErrorMessage(null);
-      }, 3000);
-      return;
-    }
-
     setdisableForm(true);
     try {
       await axios.post(

--- a/app/(system)/first-access/page.tsx
+++ b/app/(system)/first-access/page.tsx
@@ -22,15 +22,28 @@ import { redirect } from "next/navigation";
 import axios from "axios";
 import { API_BASE_URL } from "@/shared/api";
 
-const formSchema = z.object({
-  password: z.string().min(2, {
-    message: "A senha é obrigatória.",
-  }),
+const passwordPolicyRegex =
+  /^(?=.*[A-Z])(?=(?:.*\d){3,})(?=.*[^A-Za-z0-9]).{8,}$/;
 
-  confirmPassword: z.string().min(2, {
-    message: "A confirmação de senha é obrigatória.",
-  }),
-});
+const formSchema = z
+  .object({
+    password: z
+      .string()
+      .min(8, {
+        message: "A senha deve ter no mínimo 8 caracteres.",
+      })
+      .regex(passwordPolicyRegex, {
+        message:
+          "A senha deve conter pelo menos 1 letra maiúscula, 3 números e 1 caractere especial.",
+      }),
+    confirmPassword: z.string().min(1, {
+      message: "A confirmação de senha é obrigatória.",
+    }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    path: ["confirmPassword"],
+    message: "As senhas não conferem.",
+  });
 
 export default function FirstAccess() {
   const [disableForm, setdisableForm] = useState<boolean>(false);
@@ -57,16 +70,6 @@ export default function FirstAccess() {
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setdisableForm(true);
     setErrorMessage(null);
-
-    if (values.password !== values.confirmPassword) {
-      setErrorMessage("As senhas não conferem.");
-      form.reset();
-      setdisableForm(false);
-      setTimeout(() => {
-        setErrorMessage(null);
-      }, 2000);
-      return;
-    }
 
     try {
       await axios.post(


### PR DESCRIPTION
## Resumo
- Aplica regex de politica de senha (8+, 1 maiuscula, 3 numeros, 1 especial).
- Confirma senha via refine no schema.

## Testes
- yarn lint (falhou: erros pendentes na #10)
- QA de autenticação nao executado (dependente de envs TEST_*)

Closes #4