### PR TITLE
fix: validar e-mail

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -23,9 +23,14 @@ import axios from "axios";
 import { API_BASE_URL } from "@/shared/api";
 
 const formSchema = z.object({
-  email: z.string().min(2, {
-    message: "E-mail é obrigatório.",
-  }),
+  email: z
+    .string()
+    .min(1, {
+      message: "E-mail é obrigatório.",
+    })
+    .email({
+      message: "E-mail inválido.",
+    }),
 });
 
 export default function ForgotPassword() {

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -22,9 +22,14 @@ import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
 const formSchema = z.object({
-  username: z.string().min(2, {
-    message: "E-mail é obrigatório.",
-  }),
+  username: z
+    .string()
+    .min(1, {
+      message: "E-mail é obrigatório.",
+    })
+    .email({
+      message: "E-mail inválido.",
+    }),
 
   password: z.string().min(2, {
     message: "A senha é obrigatória.",


### PR DESCRIPTION
## Resumo
- Aplica z.string().email() com mensagens claras em login e recuperacao.

## Testes
- yarn lint (falhou: erros pendentes na #10)
- yarn test:e2e (falhou: Playwright nao conseguiu iniciar o Chromium — setsockopt/Operation not permitted)

Closes #5