### PR TITLE
chore: ajustar playwright

### DIFF
--- a/CODEX_WORKFLOWS.md
+++ b/CODEX_WORKFLOWS.md
@@ -77,6 +77,11 @@ Passos:
    - Status (Passou/Falhou)
    - Observações
 
+Se o Playwright falhar ao iniciar o Chromium (ex: `setsockopt: Operation not permitted`),
+usar um Chromium do sistema (não-snap) via `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`
+e registrar isso no relatório de QA. Snap pode falhar com `snap-confine` em
+ambientes restritos.
+
 ---
 
 ## 🔐 Template 3 – QA de Autenticação

--- a/CODEX_WORKFLOWS.md
+++ b/CODEX_WORKFLOWS.md
@@ -82,6 +82,9 @@ usar um Chromium do sistema (não-snap) via `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
 e registrar isso no relatório de QA. Snap pode falhar com `snap-confine` em
 ambientes restritos.
 
+Se o sandbox do Chromium continuar bloqueado, execute os testes com
+`PLAYWRIGHT_BROWSER=firefox` e registre a troca no relatório.
+
 ---
 
 ## 🔐 Template 3 – QA de Autenticação

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ sudo apt install -y chromium
 export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 ```
 
+If the environment still blocks Chromium sandboxing, you can switch the test
+browser:
+
+```bash
+PLAYWRIGHT_BROWSER=firefox yarn test:e2e
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/README.md
+++ b/README.md
@@ -37,12 +37,22 @@ TEST_USER_PASSWORD=sua_senha \
 yarn test:e2e
 ```
 
-If Playwright fails to launch Chromium on WSL2, install a system Chromium and
-export its path:
+If Playwright fails to launch Chromium with errors like
+`setsockopt: Operation not permitted`, prefer a non-snap system Chromium and
+point Playwright to it (or set `CHROME_BIN`):
 
 ```bash
-sudo apt install -y chromium-browser
-export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium-browser
+PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium \
+yarn test:e2e
+```
+
+Snap-based Chromium (`/usr/bin/chromium-browser`) can fail inside containers
+with `snap-confine` permission errors. Install a non-snap binary (apt Chromium
+or Google Chrome) and export its path:
+
+```bash
+sudo apt install -y chromium
+export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium
 ```
 
 ## Learn More

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -49,6 +49,32 @@ const chromiumExecutable =
   envChromiumExecutable ||
   resolveSystemChromiumExecutable() ||
   resolvePlaywrightChromiumExecutable();
+const crashpadArgs = [
+  "--disable-crashpad",
+  "--disable-crashpad-for-testing",
+  "--disable-crash-reporter",
+  "--disable-breakpad",
+  "--disable-features=Crashpad",
+  "--no-crash-upload",
+];
+const allProjects = [
+  {
+    name: "chromium",
+    use: {
+      ...devices["Desktop Chrome"],
+      chromiumSandbox: false,
+      launchOptions: {
+        executablePath: chromiumExecutable,
+        args: crashpadArgs,
+      },
+    },
+  },
+  { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+];
+const selectedBrowser = process.env.PLAYWRIGHT_BROWSER;
+const projects = selectedBrowser
+  ? allProjects.filter((project) => project.name === selectedBrowser)
+  : allProjects.filter((project) => project.name === "chromium");
 
 if (fs.existsSync(localAudioLibPath)) {
   process.env.LD_LIBRARY_PATH = [
@@ -72,18 +98,8 @@ export default defineConfig({
   use: {
     baseURL,
     headless: true,
-    chromiumSandbox: false,
-    launchOptions: {
-      executablePath: chromiumExecutable,
-      args: ["--disable-crash-reporter", "--disable-crashpad"],
-    },
     screenshot: "only-on-failure",
     trace: "off",
   },
-  projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
-  ],
+  projects,
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,10 +4,16 @@ import fs from "node:fs";
 
 const baseURL = process.env.TEST_BASE_URL || "http://localhost:3000";
 const localAudioLibPath = "/tmp/apt/libasound2/usr/lib/x86_64-linux-gnu";
-const envChromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+const envChromiumExecutable =
+  process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ||
+  process.env.CHROME_BIN ||
+  process.env.PUPPETEER_EXECUTABLE_PATH;
 const systemChromiumCandidates = [
   "/usr/bin/chromium-browser",
   "/usr/bin/chromium",
+  "/usr/bin/google-chrome",
+  "/usr/bin/google-chrome-stable",
+  "/opt/google/chrome/chrome",
   "/snap/bin/chromium",
 ];
 
@@ -20,10 +26,29 @@ const resolvePlaywrightChromiumExecutable = () => {
   }
 };
 
+const isSnapShim = (path: string) => {
+  try {
+    const stats = fs.lstatSync(path);
+    if (stats.isSymbolicLink()) {
+      const realPath = fs.realpathSync(path);
+      return realPath.includes("/snap") || realPath.endsWith("/usr/bin/snap");
+    }
+
+    return stats.size < 100 * 1024;
+  } catch {
+    return false;
+  }
+};
+
+const resolveSystemChromiumExecutable = () =>
+  systemChromiumCandidates.find(
+    (path) => fs.existsSync(path) && !isSnapShim(path)
+  );
+
 const chromiumExecutable =
   envChromiumExecutable ||
-  resolvePlaywrightChromiumExecutable() ||
-  systemChromiumCandidates.find((path) => fs.existsSync(path));
+  resolveSystemChromiumExecutable() ||
+  resolvePlaywrightChromiumExecutable();
 
 if (fs.existsSync(localAudioLibPath)) {
   process.env.LD_LIBRARY_PATH = [
@@ -50,6 +75,7 @@ export default defineConfig({
     chromiumSandbox: false,
     launchOptions: {
       executablePath: chromiumExecutable,
+      args: ["--disable-crash-reporter", "--disable-crashpad"],
     },
     screenshot: "only-on-failure",
     trace: "off",


### PR DESCRIPTION
## Resumo
- prioriza Chromium do sistema via env vars (CHROME_BIN/PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH)
- adiciona flags para reduzir crashpad no Chromium do Playwright
- documenta limitação do Chromium via snap e fluxo de QA

## Testes
- yarn lint (falhou: app/(system)/tickets/[id]/page.tsx unused vars; app/(system)/tickets/components/dialog-ticket.tsx any — issue #10)
- yarn test:e2e (falhou: crashpad setsockopt; Chromium snap falha com snap-confine)

Closes #15